### PR TITLE
Updated shutdown method and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pyinstaller to be run in any machine independent of python version or installati
      1. [Running Pryxy](#running-pryxy)
      2. [Configuring Rules](#configuring-rules)
      3. [Automated Responses](#automated-responses)
+     4. [Shutting Down](#shutting-down-the-server)
   4. [License](#4-license)
 
 ## 1. Building
@@ -66,6 +67,7 @@ All arguments are optional, and when one is not present, its default value is us
 * **-x, --proto** = The protocol for the proxy to listen to (currently only supports HTTP). defaults to `http`
 * **-d, --directory** = The effective directory containing the `.json` rule files for the handlers. Defaults to `./`
 * **-v, --verbose** = Print more information with the logging process. Defaults to `False`
+* **--no-block** = Will not wait for client's connection shutdown to close the server. **WARNING:** This may result in the TCP connection lingering on the client's side. Defaults to `False`
 
 ### Configuring Rules
 
@@ -152,6 +154,12 @@ With this said, there are some cases where Pryxy may respond not according to th
 * And finally, if the request's HTTP version is 2.0 or above: **505 HTTP Version Not Supported**
 
 > NOTE: This is subject to change in the future, if features to add request validations or the like are implemented
+
+### Shutting down the server
+
+Just send a `SIGINT` or `SIGTERM` to the process, either via the terminal or any `kill`-like command.
+
+> WARNING: If ussing `--no-block`, you will still need to close the client's connection for new requests on the same port.
 
 ## 4. License
 

--- a/TODO
+++ b/TODO
@@ -12,8 +12,6 @@
 - [ ] Add client capabilities (send requests and receive responses)
 - [ ] Add more complex information like time between messages, payload size, header log, etc
 - [ ] Create a GUI wrapper version
-- [ ] Unit tests
-- [ ] Integration and development pipeline
 - [ ] Support other protocols (MQTT, SIP, etc...)
 - [ ] ???Integrate with wireshark???
 - [ ] ???Generate message flow log???
@@ -21,3 +19,5 @@
 ## Done
 
 - [x] Add http base handler
+- [x] Integration and development pipeline
+- [x] Initial Unit tests

--- a/server.bat
+++ b/server.bat
@@ -9,5 +9,5 @@ set host=localhost
 set port=80
 set proto=http
 set directory=%cd%\example\
-call python src\proxyserver.py -a %host% -p %port% -x %proto% -d %directory%
+call python -OO src\proxyserver.py -a %host% -p %port% -x %proto% -d %directory%
 pause

--- a/server.sh
+++ b/server.sh
@@ -9,6 +9,6 @@ host="localhost"
 port="80"
 proto="http"
 directory="$(pwd)/example/"
-python src/proxyserver.py -a $host -p $port -x $proto -d $directory
+python -OO src/proxyserver.py -a $host -p $port -x $proto -d $directory
 echo "press any key to continue..."
 read -rsn1

--- a/src/handlers/httphandler.py
+++ b/src/handlers/httphandler.py
@@ -11,17 +11,17 @@ ___________________
 by:
 Ayzurus
 """
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
-import safeprint
 import handlers.jsonrules
 import http.client
 from http.server import BaseHTTPRequestHandler
 from http import HTTPStatus
 from socket import timeout
+from utils import safeprint
 
 class HttpHandler(BaseHTTPRequestHandler):
-    server_version = "HttpHandler/" + __version__
+    server_version = "Pryxy-HttpHandler/" + __version__
     WILDCARD = "*"
 
     def __init__(self, *args, rules=None, **kwargs):

--- a/src/handlers/jsonrules.py
+++ b/src/handlers/jsonrules.py
@@ -9,7 +9,6 @@ by:
 Ayzurus
 """
 import json
-import safeprint
 
 _root_path = "./"
 

--- a/src/proxyserver.py
+++ b/src/proxyserver.py
@@ -7,16 +7,16 @@ ___________________
 by:
 Ayzurus
 """
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 import sys
-import safeprint
 import argparse
 import time
 import signal
 import socket
 import handlers.jsonrules
 import handlers.httphandler
+from utils import safeprint
 from threading import Thread
 from socketserver import TCPServer
 
@@ -53,7 +53,6 @@ class ProxyServer(Thread, CustomTCPServer):
         
     def await_shutdown(self):
         """awaits for a shutdown signal to proceed"""
-        time.sleep(0.1)
         safeprint.log("awaiting proxy shutdown...")
         while self._active:
             time.sleep(ProxyServer.THREAD_POLL_INTERVAL)

--- a/src/utils/safeprint.py
+++ b/src/utils/safeprint.py
@@ -13,6 +13,7 @@ from threading import Lock
 from datetime import datetime
 
 _PRINT_LOCK = Lock()
+_PRINT_FORMAT = "[%s] %s: %s"
 _prints_verb = False
 _prints_debug = False
 
@@ -24,7 +25,7 @@ def setup(prints_verb: bool, prints_debug: bool):
 
 def _print(level, *text, **args):
     with _PRINT_LOCK:
-        print("[" + str(datetime.now()) + "] " + level + ": " + str(*text), **args)
+        print(_PRINT_FORMAT % (str(datetime.now()), level, str(*text)), **args)
 
 def error(*text, **args):
     _print("ERROR", *text, **args)


### PR DESCRIPTION
According to the bug I had opened, it was mostly my mistake, I did not notice that the tabs on the browser wouldn't close the TCP connection until the whole browser is closed.

This PR changes the shutdown request to use SIGINT and SIGTERM instead of listening to the terminal input. Also adds an option for a non blocking shutdown that ignores the TCP connection, to be used with caution, and cleans some code